### PR TITLE
BUGFIX: make this run on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7420,9 +7420,9 @@
       }
     },
     "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -7437,9 +7437,9 @@
       "dev": true
     },
     "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -14,7 +14,7 @@ const config = {
     ]
   },
   output: {
-    path: path.join(__dirname, 'dist'),
+    path: path.resolve(__dirname, './dist'),
     filename: '[name].js',
     publicPath: '/assets/',
   },

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -33,7 +33,7 @@ const config = {
     }])
   ],
   output: {
-    path: path.join(__dirname, "./dist"),
+    path: path.resolve(__dirname, "./dist"),
     filename: '[name].js'
   }
 }

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -33,7 +33,7 @@ const config = {
     }])
   ],
   output: {
-    path: path.join(__dirname, "dist"),
+    path: path.join(__dirname, "./dist"),
     filename: '[name].js'
   }
 }


### PR DESCRIPTION
- fixing webpack path so it's an absolute path, so Windows doesn't throw error
- tested on Windows 10
  - app builds and serves
  - app hot-reloads when CSS and/or JS is changed
- OSX should continue working as before